### PR TITLE
Fix: 수정-단어와 단어 사이에 공백이 있으면 검색 안되는 오류 수정

### DIFF
--- a/api/movie.ts
+++ b/api/movie.ts
@@ -1,5 +1,10 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
-import { SearchRequestParams, DetailRequestParams } from '../src/types';
+import {
+  SearchRequestParams,
+  DetailRequestParams,
+  SearchResult,
+  MovieInfo,
+} from '../src/types';
 import axios from 'axios';
 
 const API_URL = 'https://omdbapi.com';
@@ -7,7 +12,7 @@ const { API_KEY = '' } = process.env;
 
 export default async function (req: VercelRequest, res: VercelResponse) {
   const params = req.body as SearchRequestParams | DetailRequestParams;
-  const { data } = await axios.get(API_URL, {
+  const { data } = await axios.get<SearchResult | MovieInfo>(API_URL, {
     params: { apiKey: API_KEY, ...params },
   });
   res.status(200).json(data);

--- a/src/components/MovieList.vue
+++ b/src/components/MovieList.vue
@@ -79,7 +79,7 @@ const addMyMovies = (movie: Movie) => {
     </router-link>
   </div>
   <MessageSlot
-    v-if="movieStore.movieFull"
+    v-if="movieStore.searchCompleted"
     type="default">
     불러올 영화가 없습니다!
   </MessageSlot>

--- a/src/components/SearchBar.vue
+++ b/src/components/SearchBar.vue
@@ -8,7 +8,7 @@ const search = ref('');
 const router = useRouter();
 
 const handleSubmit = async () => {
-  router.push({ name: 'Search', query: { keyword: search.value } });
+  router.push({ name: 'Search', query: { keyword: search.value.trim() } });
 };
 
 const guideMsg = {
@@ -28,7 +28,7 @@ const message = computed(() => {
   if (!search.value) {
     return guideMsg;
   }
-  if (!/^[a-zA-Z]+$/.test(search.value)) {
+  if (!/^[a-zA-Z\s]+$/.test(search.value)) {
     return warningEng;
   }
   if (search.value.length < 3) {
@@ -38,7 +38,7 @@ const message = computed(() => {
 });
 
 const submitDisabled = computed(() => {
-  return search.value.length < 3 || !/^[a-zA-Z]+$/.test(search.value);
+  return search.value.length < 3 || !/^[a-zA-Z\s]+$/.test(search.value);
 });
 
 onMounted(() => {

--- a/src/store/useMovieStore.ts
+++ b/src/store/useMovieStore.ts
@@ -1,12 +1,12 @@
 import { defineStore } from 'pinia';
-import { Movies, MovieInfo } from '../types';
+import { Movies, MovieInfo, SearchResult } from '../types';
 import axios from 'axios';
 
 interface StoreState {
   movies: null | Movies;
   movie: null | MovieInfo;
   loading: boolean;
-  movieFull: boolean;
+  searchCompleted: boolean;
 }
 
 export const useMovieStore = defineStore('movie', {
@@ -14,7 +14,7 @@ export const useMovieStore = defineStore('movie', {
     movies: null,
     movie: null,
     loading: false,
-    movieFull: false,
+    searchCompleted: false,
   }),
   actions: {
     async fetchMovies(title: string, page = 1) {
@@ -25,7 +25,7 @@ export const useMovieStore = defineStore('movie', {
           page,
         });
         if (!data.Search || data.Search.length < 10) {
-          this.movieFull = true;
+          this.searchCompleted = true;
         }
         this.movies = this.movies
           ? this.movies.concat(data.Search)

--- a/src/store/useMovieStore.ts
+++ b/src/store/useMovieStore.ts
@@ -20,7 +20,7 @@ export const useMovieStore = defineStore('movie', {
     async fetchMovies(title: string, page = 1) {
       this.loading = true;
       try {
-        const { data } = await axios.post('/api/movie', {
+        const { data } = await axios.post<SearchResult>('/api/movie', {
           s: title,
           page,
         });
@@ -39,7 +39,7 @@ export const useMovieStore = defineStore('movie', {
     async fetchMovie(id: string) {
       this.loading = true;
       try {
-        const { data } = await axios.post('/api/movie', {
+        const { data } = await axios.post<MovieInfo>('/api/movie', {
           i: id,
         });
         this.movie = data;

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -8,6 +8,12 @@ export interface Movie {
   Poster: string;
 }
 
+export interface SearchResult {
+  Search: Movies;
+  totalResults: string;
+  Response: string;
+}
+
 export interface SearchRequestParams {
   s: string;
   y?: string;


### PR DESCRIPTION
1. axios의 get, post로 받아오는 data의 타입이 any로 나오기 때문에 `SearchResult` 인터페이스를 추가하고 `get()`과 `post()`에 타입을 추가했습니다.
2. `movieFull`의 변수명의 의미가 불명확해서 `searchCompleted`로 수정했습니다.
3. 단어와 단어 사이에 공백이 있으면 검색이 안되는 오류가 있어서 정규식에 `\s`를 추가하고 `handleSubmit()`의 `search.value` 부분에 `trim()`을 추가했습니다.